### PR TITLE
fix: modify admin login & product entity is_selected type

### DIFF
--- a/src/main/java/com/choiteresa/fonation/domain/foodmarket/repository/FoodMarketRepository.java
+++ b/src/main/java/com/choiteresa/fonation/domain/foodmarket/repository/FoodMarketRepository.java
@@ -3,6 +3,7 @@ package com.choiteresa.fonation.domain.foodmarket.repository;
 
 import com.choiteresa.fonation.domain.foodmarket.entity.FoodMarket;
 import com.choiteresa.fonation.domain.foodmarket.model.FoodMarketWithDistance;
+import com.choiteresa.fonation.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,7 @@ import java.util.Optional;
 public interface FoodMarketRepository extends JpaRepository<FoodMarket,Integer> {
     List<FoodMarket> findFoodMarketsByArea(String area);
     Optional<FoodMarket> findById(Long id);
+    Optional<FoodMarket> findByAdmin(Member member);
     Optional<FoodMarket> findByNameContaining(String name);
 
     Optional<FoodMarket> findByCode(String code);

--- a/src/main/java/com/choiteresa/fonation/domain/foodmarket_product_donation_form/dto/SelectedProductDto.java
+++ b/src/main/java/com/choiteresa/fonation/domain/foodmarket_product_donation_form/dto/SelectedProductDto.java
@@ -19,7 +19,7 @@ public class SelectedProductDto {
     private int productQuantity;
     private int storeType;
     private Date expireDate;
-    private boolean isSelected;
+    private int isSelected;
 
 
     public static SelectedProductDto fromEntity(Product product){
@@ -30,7 +30,7 @@ public class SelectedProductDto {
                 .productQuantity(product.getQuantity())
                 .storeType(product.getStoreType())
                 .expireDate(product.getExpireDate())
-                .isSelected(product.isSelected())
+                .isSelected(product.getIsSelected())
                 .build();
     }
 }

--- a/src/main/java/com/choiteresa/fonation/domain/member/controller/MemberController.java
+++ b/src/main/java/com/choiteresa/fonation/domain/member/controller/MemberController.java
@@ -22,24 +22,24 @@ public class MemberController {
     @ResponseBody
     public ResponseEntity<UserRegisterResponseDto> registerUser(@RequestBody UserRegisterRequestDto memberDto){
         return ResponseEntity.ok(
-                UserRegisterResponseDto.fromEntity(memberService.registerUserMember(memberDto)));
+                memberService.registerUserMember(memberDto));
     }
     @PostMapping("/register/admin")
     @ResponseBody
     public ResponseEntity<AdminRegisterResponseDto> registerAdmin(@RequestBody AdminRegisterRequestDto memberDto){
         return ResponseEntity.ok(
-                AdminRegisterResponseDto.fromEntity(memberService.registerAdminMember(memberDto)));
+                memberService.registerAdminMember(memberDto));
     }
 
     @PostMapping("/login/user")
     public ResponseEntity<UserLoginResponseDto> loginUser(@RequestBody UserLoginRequestDto loginRequest){
         return ResponseEntity.ok(
-                UserLoginResponseDto.fromEntity(memberService.loginUser(loginRequest)));
+                memberService.loginUser(loginRequest));
     }
     @PostMapping("/login/admin")
     public ResponseEntity<AdminLoginResponseDto> loginAdmin(@RequestBody AdminLoginRequestDto loginRequest){
         return ResponseEntity.ok(
-                AdminLoginResponseDto.fromEntity(memberService.loginAdmin(loginRequest)));
+                memberService.loginAdmin(loginRequest));
     }
     @GetMapping("/summary/{member_id}")
     public ResponseEntity<SummaryResponseDto> summaryMemerInfo(@RequestBody SummaryRequestDto summaryRequest){

--- a/src/main/java/com/choiteresa/fonation/domain/member/dto/AdminLoginResponseDto.java
+++ b/src/main/java/com/choiteresa/fonation/domain/member/dto/AdminLoginResponseDto.java
@@ -7,10 +7,12 @@ import lombok.Getter;
 @Builder
 public class AdminLoginResponseDto {
     private int status;
+    private Long foodmarketId;
 
-    public static AdminLoginResponseDto fromEntity(int status) {
+    public static AdminLoginResponseDto fromEntity(int status, Long foodmarketId) {
         return AdminLoginResponseDto.builder()
                 .status(status)
+                .foodmarketId(foodmarketId)
                 .build();
     }
 }

--- a/src/main/java/com/choiteresa/fonation/domain/member/service/MemberService.java
+++ b/src/main/java/com/choiteresa/fonation/domain/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.choiteresa.fonation.domain.member.service;
 
+import com.choiteresa.fonation.domain.foodmarket.entity.FoodMarket;
+import com.choiteresa.fonation.domain.foodmarket.repository.FoodMarketRepository;
 import com.choiteresa.fonation.domain.member.dto.*;
 import com.choiteresa.fonation.domain.member.entity.Member;
 import com.choiteresa.fonation.domain.member.repository.MemberRepository;
@@ -15,70 +17,81 @@ import java.util.Optional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final RoleRepository roleRepository;
+    private final FoodMarketRepository foodMarketRepository;
 
-    public int registerUserMember(UserRegisterRequestDto memberDto){
+    public UserRegisterResponseDto registerUserMember(UserRegisterRequestDto memberDto) {
 
         Optional<Role> role = roleRepository.findById(1L);
 
-        if(role.isPresent()){
+        if (role.isPresent()) {
             System.out.println(role.isPresent());
             Member member = memberDto.toEntity(role.get());
-            if(validateMember(member.getMemberId())){
-                return -1;
+            if (validateMember(member.getMemberId())) {
+                return UserRegisterResponseDto.fromEntity(-1);
             }
             Member newMember = memberRepository.save(member);
             System.out.print(newMember);
         }
 
-        return 1;
+        return UserRegisterResponseDto.fromEntity(1);
     }
-    public int registerAdminMember(AdminRegisterRequestDto memberDto){
+
+    public AdminRegisterResponseDto registerAdminMember(AdminRegisterRequestDto memberDto) {
 
         Optional<Role> role = roleRepository.findById(2L);
 
-        if(role.isPresent()){
+        if (role.isPresent()) {
             System.out.println(role.isPresent());
             Member member = memberDto.toEntity(role.get());
-            if(validateMember(member.getMemberId())){
-                return -1;
+            if (validateMember(member.getMemberId())) {
+                return AdminRegisterResponseDto.fromEntity(-1);
             }
             Member newMember = memberRepository.save(member);
             System.out.print(newMember);
         }
 
-        return 1;
+        return AdminRegisterResponseDto.fromEntity(1);
     }
 
-    public boolean validateMember(String userId){
+    public boolean validateMember(String userId) {
         Optional<Member> findMember = memberRepository.findByMemberId(userId);
         System.out.println(findMember.isPresent());
         return findMember.isPresent();
     }
 
-    public int loginUser(UserLoginRequestDto loginRequest){
+    public UserLoginResponseDto loginUser(UserLoginRequestDto loginRequest) {
         Optional<Member> findMember = memberRepository.findByMemberId(loginRequest.getMemberId());
 
         if (findMember.isPresent() &&
                 findMember.get().getPassword().equals(loginRequest.getPassword()) &&
-                findMember.get().getRole().getRoleName().equals("user") ){
-            return 1;
+                findMember.get().getRole().getRoleName().equals("user")) {
+            return UserLoginResponseDto.fromEntity(1);
 
-        } else return -1;
+        } else return UserLoginResponseDto.fromEntity(-1);
+
     }
 
-    public int loginAdmin(AdminLoginRequestDto loginRequest){
+    public AdminLoginResponseDto loginAdmin(AdminLoginRequestDto loginRequest) {
         Optional<Member> findMember = memberRepository.findByMemberId(loginRequest.getMemberId());
 
         if (findMember.isPresent() &&
                 findMember.get().getPassword().equals(loginRequest.getPassword()) &&
-                findMember.get().getRole().getRoleName().equals("admin")){
-            return 1;
+                findMember.get().getRole().getRoleName().equals("admin")) {
+
+            Optional<FoodMarket> market = foodMarketRepository.findByAdmin(findMember.get());
+
+            if(market.isPresent()) {
+                return AdminLoginResponseDto.fromEntity(1,market.get().getId());
+            } else {
+                return AdminLoginResponseDto.fromEntity(1,-1L);
+            }
 
         } else {
-            return -1;
+            return AdminLoginResponseDto.fromEntity(-1,-1L);
         }
     }
-    public Optional<Member> summaryMemberInfo(SummaryRequestDto summaryRequest){
+
+    public Optional<Member> summaryMemberInfo(SummaryRequestDto summaryRequest) {
         Optional<Member> findMember = memberRepository.findByMemberId(summaryRequest.getMemberId());
 
         return findMember;

--- a/src/main/java/com/choiteresa/fonation/domain/product/entity/Product.java
+++ b/src/main/java/com/choiteresa/fonation/domain/product/entity/Product.java
@@ -40,5 +40,5 @@ public class Product {
     private int weight;
 
     @Column(nullable = false)
-    private boolean isSelected;
+    private int isSelected;
 }


### PR DESCRIPTION
### 구현 내용
관리자로 로그인 시 담당하고 있는 foodmarket의 id 반환 (담당하고 있는 market이 없다면 -1 반환)
센터별 물품 승인 내역을 확인 할 때 승인, 승인 거절 외에도 승인 대기 상태가 있음을 고려하여 product entity의 is_selected의 타입을 boolean -> int로 변경 (1일때 승인, -1일 때 거절, 0일 때 대기)